### PR TITLE
refactor: 更新模块路径从fatwang-go-utils到go-utils

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2024 fatwang.
+   Copyright 2024 victowong71.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# fatwang-go-utils
+# go-utils
 
-[![GoDoc](https://pkg.go.dev/badge/github.com/victorwong171/fatwang-go-utils?utm_source=godoc)](https://pkg.go.dev/github.com/victorwong171/fatwang-go-utils)
-[![Go Report Card](https://goreportcard.com/badge/github.com/victorwong171/fatwang-go-utils)](https://goreportcard.com/report/github.com/victorwong171/fatwang-go-utils)
-[![codecov](https://codecov.io/github/victorwong171/fatwang-go-utils/branch/master/graph/badge.svg?token=2XWEF1Z3ZI)](https://codecov.io/github/victorwong171/fatwang-go-utils)
-![GitHub License](https://img.shields.io/github/license/victorwong171/fatwang-go-utils)
+[![GoDoc](https://pkg.go.dev/badge/github.com/victorwong171/go-utils?utm_source=godoc)](https://pkg.go.dev/github.com/victorwong171/go-utils)
+[![Go Report Card](https://goreportcard.com/badge/github.com/victorwong171/go-utils)](https://goreportcard.com/report/github.com/victorwong171/go-utils)
+[![codecov](https://codecov.io/github/victorwong171/go-utils/branch/master/graph/badge.svg?token=2XWEF1Z3ZI)](https://codecov.io/github/victorwong171/go-utils)
+![GitHub License](https://img.shields.io/github/license/victorwong171/go-utils)
 [![Go Version](https://img.shields.io/badge/Go-1.24+-blue.svg)](https://golang.org)
-[![Build Status](https://github.com/victorwong171/fatwang-go-utils/workflows/CI/badge.svg)](https://github.com/victorwong171/fatwang-go-utils/actions)
+[![Build Status](https://github.com/victorwong171/go-utils/workflows/CI/badge.svg)](https://github.com/victorwong171/go-utils/actions)
 
 A comprehensive Go utilities library providing high-performance data structures, business components, and common utilities for modern Go applications.
 
@@ -20,13 +20,13 @@ A comprehensive Go utilities library providing high-performance data structures,
 ## 📦 Installation
 
 ```bash
-go get github.com/victorwong171/fatwang-go-utils
+go get github.com/victorwong171/go-utils
 ```
 
 ## 🏗️ Architecture
 
 ```
-fatwang-go-utils/
+go-utils/
 ├── business/          # Business logic components
 │   ├── observer/      # Event observer pattern
 │   └── publisher/      # Pub/Sub messaging
@@ -55,8 +55,8 @@ import (
     "fmt"
     "log"
 
-    "github.com/victorwong171/fatwang-go-utils/business/observer"
-    "github.com/victorwong171/fatwang-go-utils/utils"
+    "github.com/victorwong171/go-utils/business/observer"
+    "github.com/victorwong171/go-utils/utils"
 )
 
 func main() {
@@ -108,7 +108,7 @@ package main
 import (
     "fmt"
     "time"
-    "github.com/victorwong171/fatwang-go-utils/business/publisher"
+    "github.com/victorwong171/go-utils/business/publisher"
 )
 
 func main() {
@@ -163,9 +163,9 @@ package main
 
 import (
     "fmt"
-    "github.com/victorwong171/fatwang-go-utils/desc/bitmap"
-    "github.com/victorwong171/fatwang-go-utils/desc/set"
-    "github.com/victorwong171/fatwang-go-utils/desc/union_find"
+    "github.com/victorwong171/go-utils/desc/bitmap"
+    "github.com/victorwong171/go-utils/desc/set"
+    "github.com/victorwong171/go-utils/desc/union_find"
 )
 
 func main() {
@@ -196,7 +196,7 @@ package main
 
 import (
     "fmt"
-    "github.com/victorwong171/fatwang-go-utils/utils"
+    "github.com/victorwong171/go-utils/utils"
 )
 
 func main() {
@@ -278,8 +278,8 @@ go tool cover -html=coverage.out -o coverage.html
 
 ```bash
 # Clone repository
-git clone https://github.com/victorwong171/fatwang-go-utils.git
-cd fatwang-go-utils
+git clone https://github.com/victorwong171/go-utils.git
+cd go-utils
 
 # Install dependencies
 go mod download
@@ -308,8 +308,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 📞 Support
 
 - 📧 Email: victorwang171@gmail.com
-- 🐛 Issues: [GitHub Issues](https://github.com/victorwong171/fatwang-go-utils/issues)
-- 💬 Discussions: [GitHub Discussions](https://github.com/victorwong171/fatwang-go-utils/discussions)
+- 🐛 Issues: [GitHub Issues](https://github.com/victorwong171/go-utils/issues)
+- 💬 Discussions: [GitHub Discussions](https://github.com/victorwong171/go-utils/discussions)
 
 ---
 

--- a/business/observer/observer.go
+++ b/business/observer/observer.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/victorwong171/fatwang-go-utils/utils"
+	"github.com/victorwong171/go-utils/utils"
 )
 
 type Action[P any] func(ctx context.Context, params P) error

--- a/business/observer/observer_test.go
+++ b/business/observer/observer_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/victorwong171/fatwang-go-utils/utils"
+	"github.com/victorwong171/go-utils/utils"
 )
 
 func TestNewEvent(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/victorwong171/fatwang-go-utils
+module github.com/victorwong171/go-utils
 
 go 1.24.0
 

--- a/internal/logger/noop_test.go
+++ b/internal/logger/noop_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/victorwong171/fatwang-go-utils/utils"
+	"github.com/victorwong171/go-utils/utils"
 )
 
 func (n *noop) WithField(key string, value interface{}) utils.Logger {


### PR DESCRIPTION
更新所有文件中的模块引用路径，将"github.com/victorwong171/fatwang-go-utils"替换为"github.com/victorwong171/go-utils" 同时更新LICENSE中的版权信息和README.md中的项目名称及相关链接