### PR TITLE
Fix various bugs across the go-utils library

### DIFF
--- a/business/publisher/pubsub.go
+++ b/business/publisher/pubsub.go
@@ -106,13 +106,7 @@ func (p *Publisher) Evict(sub chan *Message) {
 	defer p.m.Unlock()
 	if _, exists := p.subscribers[sub]; exists {
 		delete(p.subscribers, sub)
-		// Use select to avoid closing an already closed channel
-		select {
-		case <-sub:
-			// channel is already closed
-		default:
-			close(sub)
-		}
+		close(sub)
 	}
 }
 
@@ -127,13 +121,7 @@ func (p *Publisher) Close() {
 	defer p.m.Unlock()
 	for sub := range p.subscribers {
 		delete(p.subscribers, sub)
-		// Use select to avoid closing an already closed channel
-		select {
-		case <-sub:
-			// channel is already closed
-		default:
-			close(sub)
-		}
+		close(sub)
 	}
 }
 

--- a/desc/bitmap/bitmap.go
+++ b/desc/bitmap/bitmap.go
@@ -41,5 +41,5 @@ func (b *bitMap) Check(num uint) bool {
 	if num > b.vmax {
 		return false
 	}
-	return b.graph[num>>3]&(1<<(num%8)) == 1
+	return b.graph[num>>3]&(1<<(num%8)) != 0
 }

--- a/desc/bitmap/bitmap_test.go
+++ b/desc/bitmap/bitmap_test.go
@@ -96,6 +96,17 @@ func Test_bitMap_Check(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "check bit that is set",
+			fields: fields{
+				vmax:  defaultMax,
+				graph: func() []byte { g := make([]byte, size, size); g[1] = 4; return g }(),
+			},
+			args: args{
+				num: 10,
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -37,7 +37,11 @@ func GenerateRandomIntList(size int, edge1, edge2 int) []int {
 		edge1, edge2 = edge2, edge1
 	}
 	for i := 0; i < size; i++ {
-		list[i] = rand.Intn(edge2-edge1) + edge1
+		if edge1 == edge2 {
+			list[i] = edge1
+		} else {
+			list[i] = rand.Intn(edge2-edge1) + edge1
+		}
 	}
 	return list
 }
@@ -57,7 +61,6 @@ func CurrentLimit(limit int, workList []func() error, enableError bool) error {
 
 	eg := new(errgroup.Group)
 	limitCh := make(chan struct{}, limit)
-	defer close(limitCh)
 
 	for _, w := range workList {
 		work := w

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -115,6 +115,14 @@ func TestGenerateRandomIntList(t *testing.T) {
 				edge2: 1,
 			},
 		},
+		{
+			name: "edge1 == edge2",
+			args: args{
+				size:  3,
+				edge1: 2,
+				edge2: 2,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes several bugs across the go-utils library.
1. In `business/publisher/pubsub.go`, removing the buggy `select` statement that incorrectly skipped closing channels or consumed messages. Replaced it with a safe `close(sub)` after deleting it from the map.
2. In `desc/bitmap/bitmap.go`, fixed the bitwise logic in `Check()` to use `!= 0` instead of `== 1`.
3. In `utils/utils.go`, removed an unsafe `defer close(limitCh)` that could lead to panics if workers attempt to send to the limit channel.
4. In `utils/utils.go`, added a guard in `GenerateRandomIntList` to prevent `rand.Intn(0)` panic when `edge1 == edge2`.

---
*PR created automatically by Jules for task [11395067552384090838](https://jules.google.com/task/11395067552384090838) started by @victorwong171*